### PR TITLE
File resource to configure bolt's global modulepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ curl -d "@test_params.json" --insecure --header "$auth_header" "$uri"
 
 - This first version of the `puppet_bolt_server` has been tested only on RHEL 7 and 8 based systems.
 - Requires Puppet ">= 6.21.0 < 8.0.0"
+- Currently, you can only run Plans from the Production environment.
 - **Warning** There is no rate limit to run Plans, we tested this module in our lab and it successfully handled up to 200 concurrent plans with a Bolt Server with the following specs:
     - 8 GB RAM
     - CPU Intel Xeon Platinum 8000 series, 4-cores

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,8 +33,8 @@ class puppet_bolt_server (
     content => to_yaml ( {
         'modulepath' => {
           'server_urls' => [
-            '"/etc/puppetlabs/code/environments/production/site-modules"',
-            '"/etc/puppetlabs/code/environments/production/modules"',
+            '/etc/puppetlabs/code/environments/production/site-modules',
+            '/etc/puppetlabs/code/environments/production/modules',
           ],
         },
     }),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,12 +31,10 @@ class puppet_bolt_server (
   file { '/root/.puppetlabs/bolt/bolt-project.yaml':
     ensure  => file,
     content => to_yaml ( {
-        'modulepath' => {
-          'server_urls' => [
-            '/etc/puppetlabs/code/environments/production/site-modules',
-            '/etc/puppetlabs/code/environments/production/modules',
-          ],
-        },
+        'modulepath' => [
+          '/etc/puppetlabs/code/environments/production/site-modules',
+          '/etc/puppetlabs/code/environments/production/modules',
+        ],
     }),
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,18 @@ class puppet_bolt_server (
     content => $puppet_token.unwrap,
   }
 
+  file { '/root/.puppetlabs/bolt/bolt-project.yaml':
+    ensure  => file,
+    content => to_yaml ( {
+        'modulepath' => {
+          'server_urls' => [
+            '"/etc/puppetlabs/code/environments/production/site-modules"',
+            '"/etc/puppetlabs/code/environments/production/modules"',
+          ],
+        },
+    }),
+  }
+
   file { '/root/.puppetlabs/etc/bolt/bolt-defaults.yaml':
     ensure  => file,
     content => to_yaml ( {


### PR DESCRIPTION
### Changes

I'm adding a new File resource to the manifest to enforce the creation of the global `bolt-project.yaml` file.

We need to it to configure the `modulepath` to load Tasks and Plans from the control-repo.

**Example:**

```
# /root/.puppetlabs/bolt/bolt-project.yaml
---
modulepath:
  - "/etc/puppetlabs/code/environments/production/site-modules"
  - "/etc/puppetlabs/code/environments/production/modules"
```