### PR TITLE
Readme docs review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,34 @@
 # puppet_bolt_server
 
-This module installs and configures Bolt to use a local PuppetDB and the PCP transport
+This module installs and configures Bolt to use a local PuppetDB and the Puppet Communications Protocol (PCP) transport.
 
 ## Table of Contents
 
 1. [Description](#description)
-1. [Setup - The basics of getting started with puppet_bolt_server](#setup)
-    * [What puppet_bolt_server affects](#what-puppet_bolt_server-affects)
-1. [Installation - Step by step guide](#installation)
-1. [Usage - Configuration options and additional functionality](#usage)
-1. [Limitations - OS compatibility, etc.](#limitations)
+1. [Installation](#installation)
+1. [Usage](#usage)
+1. [Limitations](#limitations)
 
 ## Description
 
-This module aims to configure a dedicated Puppet Enterprise compiler to become a Bolt Server, with the intention of offloading plan execution from Orchestrator on the Primary server, to Bolt on the Bolt server. A compiler is ideal because it already has access to Puppet Enterprise, code manager, and its local PuppetDB.
-
-## Setup
+This module aims to configure a dedicated Puppet Enterprise (PE) compiler to become a Bolt server. The intention is to offload plan execution from Orchestrator on the Primary server to Bolt on the Bolt server. A compiler is ideal because it already has access to PE, Code Manager, and its local PuppetDB.
 
 ### What puppet_bolt_server affects
 
-The `puppet_bolt_server` module will perform the following activities:
+The `puppet_bolt_server` module performs these activities:
 
 * Install Bolt on the node.
 * Create the `/root/.puppetlabs/etc/bolt/bolt-defaults.yaml` file with custom configuration to:
-    * Use the PCP transport
-    * Use the local PuppetDB for queries
-    * Consume a Puppet token
+    * Use the PCP transport.
+    * Use the local PuppetDB for queries.
+    * Consume a Puppet token.
 
 ## Installation
 
-**Quickstart:** Configure the `puppet_bolt_server` using the PE Console
-
-This setup will help you to quickly configure the `puppet_bolt_server` in your existing PE server.
+**Quickstart:** Use the PE console to configure the `puppet_bolt_server` in your existing PE server.
 
 1. Add the [puppetlabs-puppet_bolt_server](https://github.com/puppetlabs/puppetlabs-puppet_bolt_server) to your control repo.
-1. Add a new Node Group from the PE Console
+1. Add a new node group in the PE console:
 
    ```
      Parent name: PE Infrastructure
@@ -42,30 +36,29 @@ This setup will help you to quickly configure the `puppet_bolt_server` in your e
      Environment: production
    ```
 
-1. Add the class `puppet_bolt_server` to the Bolt Sever group created in the step above.
-1. Add your compiler dedicated to running Bolt to the group using the Rules tab. Note that this compiler should not be in the compiler pool for catalog compilation.
-1. Add your puppet token (Sensitive string) in the Configuration data tab
-
-   - We recommend you create a service user inside PE RBAC and choose an appropriate lifetime for its token.
-   - Generate a token with a lifetime of 1 year: `puppet access login --lifetime 1y`
+1. Add the `puppet_bolt_server` class to your Bolt Server node group.
+1. On the Rules tab, add the dedicated compiler (for running Bolt) to the group. This compiler must not be in the compiler pool for catalog compilation.
+1. On the Configuration data tab, add your puppet token (sensitive string).
 
    ```
     Class: puppet_bolt_server
     Parameter: puppet_token
-    Value: 'insert-your-puppet-token-here'
+    Value: '<PUPPET_TOKEN>'
    ```
 
+   - We recommend creating a service user inside PE RBAC and choosing an appropriate lifetime for its token.
+   - Use this command to generate a token with a one-year lifetime: `puppet access login --lifetime 1y`
 1. Commit your changes.
-1. Run Puppet on this Node Group.
+1. Run Puppet on the Bolt Server node group.
 
 ## Usage
 
-After Puppet applies the changes described in the installation steps, you should end up with the following files in the Bolt server:
+After completing the installation steps, your Bolt server should have these files:
 
 - `/root/.puppetlabs/etc/bolt/bolt-defaults.yaml`
 - `/root/.puppetlabs/token`
 
-To test that everything was configured properly, we can run any Bolt plan that runs a PuppetDB query, for example:
+To test that everything is configured properly, you can run any Bolt plan that runs a PuppetDB query, such as this test plan:
 
 ```
 # /root/Projects/local_plan/plans/test.pp
@@ -77,11 +70,11 @@ plan local_plan::test(
 }
 ```
 
-Run the Bolt plan:
+Run the test plan with:
 
 `bolt plan run local_plan::test`
 
-We should see the PuppetDB query results in the terminal, and if we inspect the `puppetdb-access.log` there should be a log with a call to the local PuppetDB with a 200 Ok HTTP status:
+You should get the PuppetDB query results in the terminal. If you inspect the `puppetdb-access.log`, you should find a log with a call to the local PuppetDB returning a `200 OK` HTTP status. For example:
 
 ```
 $ less /var/log/puppetlabs/puppetdb/puppetdb-access.log
@@ -89,45 +82,47 @@ $ less /var/log/puppetlabs/puppetdb/puppetdb-access.log
 127.0.0.1 - - [01/Nov/2022:15:56:21 +0000] "POST /pdb/query/v4 HTTP/1.1" 200 1793 "-" "HTTPClient/1.0 (2.8.3, ruby 2.7.6 (2022-04-12))" 99 21 -
 ```
 
-### Running a Plan via taskplan from the Primary Server
+### Run a plan via `taskplan` from the primary server
 
-We recommend to install the [`taskplan` module](https://forge.puppet.com/modules/reidmv/taskplan).
+We recommend installing the [`taskplan` module](https://forge.puppet.com/modules/reidmv/taskplan).
 
-- The `taskplan` module allows us to run a Task that runs a Plan using Bolt.
+The `taskplan` module allows you to run a task that uses Bolt to run a plan.
 
-**Running a Plan on the Bolt Server**
+#### Run a plan on the Bolt server
 
-This is an overview of the internal process when you offload the Plan execution from the PE Primary server to the Bolt server:
+This is an overview of the internal process when you offload plan execution from your PE primary server to a Bolt server:
 
-1. Someone requests Orchestrator to run the `taskplan` Task on the Bolt server
-1. The `taskplan` Task runs on the Bolt server
-1. The Task starts Bolt with the "bolt plan run" command
-1. Bolt starts and runs the Plan
+1. Someone requests Orchestrator to run the `taskplan` task on the Bolt server.
+1. The `taskplan` task runs on the Bolt server.
+1. The task starts Bolt with the `bolt plan run` command.
+1. Bolt starts and runs the plan
 
 ![bolt-server-process](diagrams/bolt-server-exec-processes.png "Bolt server execution process")
 
-**Example 1**
+#### Example 1
 
-In this example, we will use `puppet task run` to run the `taskplan` Task on the Bolt server.
+This example uses `puppet task run` to run the `taskplan` task on the Bolt server.
 
 Required parameters:
 
-- Choose one of your existing basic Plans, or create one that receives a parameter, `message` in this case.
-- Use the certname of your Bolt Server
+- Choose one of your existing, basic plans or create one that receives a parameter (such as `message`).
+- Use your Bolt server's certname.
 
-From the PE Primary server CLI we will run:
+From the PE primary server CLI, run:
 
 ```
-puppet task run taskplan --params '{"plan":"a-test-plan", "params":{"message": "Hello world!"}, "debug":true}' -n insert-here-the-bolt-server-certname
+puppet task run taskplan --params '{"plan":"<PLAN_NAME>", "params":{"message": "Hello world!"}, "debug":true}' -n <BOLT_SERVER_CERTNAME>
 ```
 
-This will trigger a Task run (`taskplan`) and the task will run the Plan we specified in the parameters directly on the Bolt server. This is a simple way to offload Plan execution from Orchestrator to a dedicated Bolt server, thereby alleviating CPU and memory load on the Primary Server.
+This triggers a `taskplan` task run, and the task runs the plan on the Bolt server according to the specified parameters.
 
-**Example 2**
+This offloads plan execution from Orchestrator to a dedicated Bolt server, which alleviates CPU and memory load on the primary server.
 
-Now in this 2nd example, we will use the Orchestrator API directly to trigger a Task run. This can be done from any system that has the Puppet RBAC token and has connectivity to the PE primary on port 8143.
+#### Example 2
 
-We will run the `taskplan` task again, targetting our Bolt server. Here is an example you can use:
+This example uses the Orchestrator API to trigger a task run. You can do this from any system connected to your PE primary server (over port 8143) and that has a Puppet RBAC token.
+
+Prepare a JSON body to run `taskplan` task, targetting the Bolt server. For example:
 
 ```
 # test_params.json
@@ -136,19 +131,19 @@ We will run the `taskplan` task again, targetting our Bolt server. Here is an ex
   "environment" : "production",
   "task" : "taskplan",
   "params" : {
-    "plan" : "a-test-plan",
+    "plan" : "<PLAN_NAME>",
     "params" : { "message": "Hello world!" },
     "debug" : true
   },
   "scope" : {
-    "nodes" : ["insert-here-the-bolt-server-certname"]
+    "nodes" : ["<BOLT_SERVER_CERTNAME"]
   }
 }
 ```
 
-Make sure to change the `params.plan`, `params.params`, and the `scope.nodes` to your own case.
+Make sure to change the `params.plan`, `params.params`, and the `scope.nodes` according to your own test plan.
 
-Now to run the task we will use `curl`:
+Use `curl` to trigger the Ochrestrator API and run the task:
 
 ```
 auth_header="X-Authentication: $(puppet-access show)"
@@ -159,10 +154,10 @@ curl -d "@test_params.json" --insecure --header "$auth_header" "$uri"
 
 ## Limitations
 
-- This first version of the `puppet_bolt_server` has been tested only on RHEL 7 and 8 based systems.
-- Requires Puppet ">= 6.21.0 < 8.0.0"
-- Currently, you can only run Plans from the Production environment.
-- **Warning** There is no rate limit to run Plans, we tested this module in our lab and it successfully handled up to 200 concurrent plans with a Bolt Server with the following specs:
+- `puppet_bolt_server` is tested only on RHEL 7 and 8 based systems.
+- Requires Puppet >= 6.21.0 < 8.0.0
+- This module only supports running plans from the Production environment.
+- **Warning:** There is no rate limit to run plans. Tests showed this module could successfully handle up to 200 concurrent plans on a Bolt server with these specs:
     - 8 GB RAM
-    - CPU Intel Xeon Platinum 8000 series, 4-cores
+    - CPU Intel Xeon Platinum 8000 series, 4 cores
 


### PR DESCRIPTION
I made quite a few changes. I apologize that they are in one commit.

- Table of contents should contain only the titles of the sections. No need to include subsections unless there starts to be a lot of subsections.
- Not sure about the mention of Puppet 8 in the Limitations. Is this module being released before or after Puppet 8? If before, I'd change it to the latest version in Puppet 7 stream. 
- The editor I was using didn't like the `<` in `Requires Puppet >= 6.21.0 < 8.0.0`. I'm not sure if needs to be escaped or if it was just my editor being touchy about it.