### PR TITLE
adds a spec_helper_local to trigger Coverage report

### DIFF
--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -18,6 +18,7 @@ describe 'puppet_bolt_server' do
 
       context 'configures bolt' do
         it { is_expected.to contain_file('puppet-token') }
+        it { is_expected.to contain_file('/root/.puppetlabs/bolt/bolt-project.yaml') }
         it { is_expected.to contain_file('/root/.puppetlabs/etc/bolt/bolt-defaults.yaml') }
       end
     end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -9,6 +9,7 @@ describe 'puppet_bolt_server' do
       let(:params) { { puppet_token: sensitive('secret_token_here') } }
 
       it { is_expected.to compile }
+      it { is_expected.to have_resource_count(5) }
 
       context 'installs bolt' do
         it { is_expected.to contain_package('puppet-tools-release') }

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |c|
-    c.after(:suite) do
-        RSpec::Puppet::Coverage.report!
-    end
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!
+  end
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,7 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+    c.after(:suite) do
+        RSpec::Puppet::Coverage.report!
+    end
+end


### PR DESCRIPTION
### Changes

- I'm adding `Spec::Puppet::Coverage.report`
- And including a spec example to make sure we have the resource to create the global `bolt-project.yaml` to configure the `modulepath`