### PR TITLE
(maint) Fix installation failures

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,8 +5,8 @@
 #   include puppet_bolt_server
 #
 # @param puppet_token
-#   This should be a token with permissions to launch Orchestrator jobs.  
-#   Generate a token with a lifetime of 1 year: puppet access login --lifetime 1y 
+#   This should be a token with permissions to launch Orchestrator jobs.
+#   Generate a token with a lifetime of 1 year: puppet access login --lifetime 1y
 #
 class puppet_bolt_server (
   Sensitive[String] $puppet_token,
@@ -22,10 +22,16 @@ class puppet_bolt_server (
     require => Package['puppet-tools-release'],
   }
 
+  $pl_root = '/root/.puppetlabs'
+  file { [$pl_root, "${pl_root}/bolt", "${pl_root}/etc", "${pl_root}/etc/bolt"]:
+    ensure => directory,
+  }
+
   file { 'puppet-token':
     ensure  => file,
     path    => '/root/.puppetlabs/token',
     content => $puppet_token.unwrap,
+    require => File[$pl_root],
   }
 
   file { '/root/.puppetlabs/bolt/bolt-project.yaml':
@@ -36,6 +42,7 @@ class puppet_bolt_server (
           '/etc/puppetlabs/code/environments/production/modules',
         ],
     }),
+    require => File["${pl_root}/bolt"],
   }
 
   file { '/root/.puppetlabs/etc/bolt/bolt-defaults.yaml':
@@ -55,6 +62,6 @@ class puppet_bolt_server (
           'server_urls' => ['http://localhost:8080'],
         },
     }),
-    require => File['puppet-token'],
+    require => File['puppet-token', "${pl_root}/etc/bolt"],
   }
 }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -9,7 +9,7 @@ describe 'puppet_bolt_server' do
       let(:params) { { puppet_token: sensitive('secret_token_here') } }
 
       it { is_expected.to compile }
-      it { is_expected.to have_resource_count(5) }
+      it { is_expected.to have_resource_count(9) }
 
       context 'installs bolt' do
         it { is_expected.to contain_package('puppet-tools-release') }
@@ -17,6 +17,10 @@ describe 'puppet_bolt_server' do
       end
 
       context 'configures bolt' do
+        it { is_expected.to contain_file('/root/.puppetlabs') }
+        it { is_expected.to contain_file('/root/.puppetlabs/bolt') }
+        it { is_expected.to contain_file('/root/.puppetlabs/etc') }
+        it { is_expected.to contain_file('/root/.puppetlabs/etc/bolt') }
         it { is_expected.to contain_file('puppet-token') }
         it { is_expected.to contain_file('/root/.puppetlabs/bolt/bolt-project.yaml') }
         it { is_expected.to contain_file('/root/.puppetlabs/etc/bolt/bolt-defaults.yaml') }


### PR DESCRIPTION
When running the initial puppet run to install everything, on a newly created compiler puppet fails to write the token and bolt-project files because the /root/.puppetlabs/ dirs don't exist.

This commit adds resources to the init manifest for ensuring the parent dirs of the token and project files exist before attempting to create the files.