### PR TITLE
Feature/sets bolt log path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,7 +58,7 @@ class puppet_bolt_server (
         'log'        => {
           '/var/log/puppetlabs/bolt-server/bolt-server.log' => {
             'append' => true,
-            'level'  => 'info',
+            'level'  => 'trace',
           },
         },
     }),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@ class puppet_bolt_server (
     owner   => 'root',
     group   => 'root',
     recurse => true,
-    mode    => '0755',
+    mode    => '0750',
   }
 
   file { "${pl_logs_base}/bolt-server/bolt-server.log":
@@ -62,7 +62,7 @@ class puppet_bolt_server (
           },
         },
     }),
-    require => File["${pl_root}/bolt", "${pl_logs_base}/bolt-server/bolt-server.log"],
+    require => File["${pl_root}/bolt"],
   }
 
   file { '/root/.puppetlabs/etc/bolt/bolt-defaults.yaml':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,20 @@ class puppet_bolt_server (
     require => File[$pl_root],
   }
 
+  $pl_logs_base = '/var/log/puppetlabs'
+  file { "${pl_logs_base}/bolt-server":
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    recurse => true,
+    mode    => '0755',
+  }
+
+  file { "${pl_logs_base}/bolt-server/bolt-server.log":
+    ensure  => file,
+    require => File["${pl_logs_base}/bolt-server"],
+  }
+
   file { '/root/.puppetlabs/bolt/bolt-project.yaml':
     ensure  => file,
     content => to_yaml( {
@@ -48,7 +62,7 @@ class puppet_bolt_server (
           },
         },
     }),
-    require => File["${pl_root}/bolt"],
+    require => File["${pl_root}/bolt", "${pl_logs_base}/bolt-server/bolt-server.log"],
   }
 
   file { '/root/.puppetlabs/etc/bolt/bolt-defaults.yaml':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,15 @@
 #   This should be a token with permissions to launch Orchestrator jobs.
 #   Generate a token with a lifetime of 1 year: puppet access login --lifetime 1y
 #
+# @param bolt_log_level
+#   This Enum (String) configures the log level in the bolt-project configuration file
+#   By default the log level is set to 'debug'
+#   For more information, please read the Bolt logs doc:
+#     https://puppet.com/docs/bolt/latest/logs.html#log-levels
+#
 class puppet_bolt_server (
   Sensitive[String] $puppet_token,
+  Enum['trace', 'debug', 'info', 'warn', 'error', 'fatal'] $bolt_log_level  = 'debug',
 ) {
   package { 'puppet-tools-release':
     ensure => present,
@@ -58,7 +65,7 @@ class puppet_bolt_server (
         'log'        => {
           '/var/log/puppetlabs/bolt-server/bolt-server.log' => {
             'append' => true,
-            'level'  => 'trace',
+            'level'  => $bolt_log_level,
           },
         },
     }),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,12 @@ class puppet_bolt_server (
           '/etc/puppetlabs/code/environments/production/site-modules',
           '/etc/puppetlabs/code/environments/production/modules',
         ],
+        'log'        => {
+          '/var/log/puppetlabs/bolt-server.log' => {
+            'append' => true,
+            'level'  => 'info',
+          },
+        },
     }),
     require => File["${pl_root}/bolt"],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@ class puppet_bolt_server (
           '/etc/puppetlabs/code/environments/production/modules',
         ],
         'log'        => {
-          '/var/log/puppetlabs/bolt-server.log' => {
+          '/var/log/puppetlabs/bolt-server/bolt-server.log' => {
             'append' => true,
             'level'  => 'info',
           },

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -9,7 +9,7 @@ describe 'puppet_bolt_server' do
       let(:params) { { puppet_token: sensitive('secret_token_here') } }
 
       it { is_expected.to compile }
-      it { is_expected.to have_resource_count(9) }
+      it { is_expected.to have_resource_count(11) }
 
       context 'installs bolt' do
         it { is_expected.to contain_package('puppet-tools-release') }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -24,6 +24,7 @@ describe 'puppet_bolt_server' do
         it { is_expected.to contain_file('puppet-token') }
         it { is_expected.to contain_file('/root/.puppetlabs/bolt/bolt-project.yaml') }
         it { is_expected.to contain_file('/root/.puppetlabs/etc/bolt/bolt-defaults.yaml') }
+        it { is_expected.to contain_file('/var/log/puppetlabs/bolt-server/bolt-server.log') }
       end
     end
   end


### PR DESCRIPTION
### Changes

In this PR I'm setting a default Log file for Bolt under `/var/log/puppetlabs/bolt-server/bolt-server.log`, the log level is set to `trace` to get most of the details in the log.

Example:

```
$ tail -f /var/log/puppetlabs/bolt-server/bolt-server.log

...
2022-12-13T10:34:31.892850 DEBUG  [main] [Bolt::PAL] Loading modules from /opt/puppetlabs/bolt/lib/ruby/gems/2.7.0/gems/bolt-3.26.1/bolt-modules:/etc/puppetlabs/code/environments/production/site-modules:/etc/puppetlabs/code/environments/production/modules:/root/.puppetlabs/bolt/.modules:/opt/puppetlabs/bolt/lib/ruby/gems/2.7.0/gems/bolt-3.26.1/modules
2022-12-13T10:34:31.894065 DEBUG  [main] [Bolt::Inventory] Tried to load inventory from /root/.puppetlabs/bolt/inventory.yaml, but the file does not exist
2022-12-13T10:34:31.896695 TRACE  [main] [Bolt::Analytics::NoopClient] Skipping submission of 'plan_run' screenview because analytics is disabled
2022-12-13T10:34:32.640050 INFO   [main] [Bolt::Logger] Loaded default project from '/root/.puppetlabs/bolt'
2022-12-13T10:34:32.640339 DEBUG  [main] [Bolt::Logger] Loaded configuration from /root/.puppetlabs/etc/bolt/bolt-defaults.yaml
2022-12-13T10:34:32.640458 DEBUG  [main] [Bolt::Logger] Analytics opt-out is set, analytics will be disabled
2022-12-13T10:34:32.642430 DEBUG  [main] [Bolt::Executor] Started with 100 max thread(s)
...
```