### PR TITLE
locks bolt version to 3.26.2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class puppet_bolt_server (
   }
 
   package { 'puppet-bolt':
-    ensure  => present,
+    ensure  => '3.26.2',
     name    => 'puppet-bolt',
     require => Package['puppet-tools-release'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class puppet_bolt_server (
           '/etc/puppetlabs/code/environments/production/modules',
         ],
         'log'        => {
+          'bolt-debug.log'                                  => disable,
           '/var/log/puppetlabs/bolt-server/bolt-server.log' => {
             'append' => true,
             'level'  => $bolt_log_level,

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.28.0 < 7.21.0"
+      "version_requirement": ">= 6.28.0 <= 7.21.0"
     }
   ],
   "pdk-version": "2.5.0",

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 6.28.0 < 7.21.0"
     }
   ],
   "pdk-version": "2.5.0",


### PR DESCRIPTION
### Changes

Making sure we install the same Bolt version that we used for testing

**Bonus:**

1. [I'm disabling the Bolt's default debug log](https://puppet.com/docs/bolt/latest/logs.html#the-bolt-debuglog-file) that is created at the root of the project
2. Changes the Puppet requirements in the module's metadata to prevent customers from deploying the module on unsupported PE versions ([raised as an issue](https://github.com/puppetlabs/puppetlabs-puppet_bolt_server/issues/12))